### PR TITLE
Add onboarding payment gateway setup methods

### DIFF
--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -1747,4 +1747,23 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		return $payment_channels;
 	}
 
+	/**
+	 * Get required setting keys for setup.
+	 *
+	 * @return array Array of setting keys used for setup.
+	 */
+	public function get_required_settings_keys() {
+		return array( 'live_public_key', 'live_secret_key' );
+	}
+
+	/**
+	 * Get help text to display during quick setup.
+	 */
+	public function get_setup_help_text() {
+		return sprintf(
+			__( 'Your API details can be obtained from your <a href="%s">Paystack account</a>.', 'woo-paystack' ),
+			'https://dashboard.paystack.com/#/settings/developer'
+		);
+	}
+
 }

--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -255,6 +255,8 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		// Webhook listener/API hook.
 		add_action( 'woocommerce_api_tbz_wc_paystack_webhook', array( $this, 'process_webhooks' ) );
 
+		add_filter( 'woocommerce_gateway_' . $this->id . '_settings_values', array( $this, 'update_quick_setup_settings' ) );
+
 		// Check if the gateway can be used.
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = false;
@@ -1764,6 +1766,18 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 			__( 'Your API details can be obtained from your <a href="%s">Paystack account</a>.', 'woo-paystack' ),
 			'https://dashboard.paystack.com/#/settings/developer'
 		);
+	}
+
+	/**
+	 * Updates the currency and test mode when setting up via the quick setup.
+	 */
+	public function update_quick_setup_settings( $settings ) {
+		if ( ! empty( $settings['live_public_key'] ) && ! empty( $settings['live_secret_key'] ) ) {
+			$settings['testmode'] = 'no';
+			update_option( 'woocommerce_currency', 'ZAR' );
+		}
+
+		return $settings;
 	}
 
 }

--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -255,7 +255,7 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		// Webhook listener/API hook.
 		add_action( 'woocommerce_api_tbz_wc_paystack_webhook', array( $this, 'process_webhooks' ) );
 
-		add_filter( 'woocommerce_gateway_' . $this->id . '_settings_values', array( $this, 'update_quick_setup_settings' ) );
+		add_filter( 'woocommerce_gateway_' . $this->id . '_settings_values', array( $this, 'update_onboarding_settings' ) );
 
 		// Check if the gateway can be used.
 		if ( ! $this->is_valid_for_use() ) {
@@ -1771,7 +1771,7 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 	/**
 	 * Updates the currency and test mode when setting up via the quick setup.
 	 */
-	public function update_quick_setup_settings( $settings ) {
+	public function update_onboarding_settings( $settings ) {
 		if ( ! empty( $settings['live_public_key'] ) && ! empty( $settings['live_secret_key'] ) ) {
 			$settings['testmode'] = 'no';
 			update_option( 'woocommerce_currency', 'ZAR' );

--- a/includes/class-wc-gateway-paystack.php
+++ b/includes/class-wc-gateway-paystack.php
@@ -1780,4 +1780,13 @@ class WC_Gateway_Paystack extends WC_Payment_Gateway_CC {
 		return $settings;
 	}
 
+	/**
+	 * Determine if the gateway still requires setup.
+	 *
+	 * @return bool
+	 */
+	public function needs_setup() {
+		return ! $this->get_option( 'live_public_key' ) || ! $this->get_option( 'live_secret_key' ) || get_option( 'woocommerce_currency', 'USD' ) !== 'ZAR';
+	}
+
 }


### PR DESCRIPTION
This PR adds the methods needed to allow setup of Paystack during onboarding.

Part of the remote payment gateways project ( woocommerce/woocommerce#32258 ).

### Screenshots

<img width="703" alt="Screen Shot 2021-05-27 at 12 31 59 PM" src="https://user-images.githubusercontent.com/10561050/119863444-8f8c6e00-bee7-11eb-9cf9-11441970abd8.png">
<img width="711" alt="Screen Shot 2021-05-27 at 12 31 23 PM" src="https://user-images.githubusercontent.com/10561050/119863446-90250480-bee7-11eb-8b8d-a0107adf292b.png">

### Testing

1. Install and activate this plugin in your `plugins/` directory matching the wp.org slug.  `woo-paystack`
2. Install and activate the development version of [WooCommerce Admin](https://github.com/woocommerce/woocommerce-admin) ( `git clone https://github.com/woocommerce/woocommerce-admin.git && cd woocommerce-admin && composer install && npm i && npm run build` ).
3. Make sure South Africa is selected as the store country under WooCommerce general settings.
2. Navigate to the Paystack gateway in the payments task `/wp-admin/admin.php?page=wc-admin&task=payments`
3. Fill out the required setting fields.
4. Make sure that the Paystack gateway is moved to the "Enabled payment gateways" section.
5. Make sure that settings are persisted on page refresh.
6. Make sure the currency is updated to `ZAR` after saving settings from the payment task.